### PR TITLE
Avoid defining _MSC_VER

### DIFF
--- a/include/yall/msvc_defines.h
+++ b/include/yall/msvc_defines.h
@@ -28,17 +28,17 @@
  */
 
 // Used to suppress GCC warning from -Wundef
-#ifdef __linux__
-#	define _MSC_VER 0
-#endif
+#ifndef __linux__
 
 // MSVC 12.0 _MSC_VER == 1800 (Visual Studio 2013)
-#if (_MSC_VER == 1800)
-#	define inline __inline
-#	define __func__ __FUNCTION__
-#endif
+#	if (_MSC_VER == 1800)
+#		define inline __inline
+#		define __func__ __FUNCTION__
+#	endif
 
 // MSVC 14.0 _MSC_VER == 1900 (Visual Studio 2015)
-#if (0 < _MSC_VER && _MSC_VER < 1900)
-#	define snprintf _snprintf
+#	if (0 < _MSC_VER && _MSC_VER < 1900)
+#		define snprintf _snprintf
+#	endif
+
 #endif


### PR DESCRIPTION
Avoiding defining macro `_MSC_VER` which could lead to errors.

Fix #141 