### PR TITLE
Feature/fix stackoverflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Deprecated
 ### Removed
 ### Fixed
+* Stack overflow when too many messages are printed
 ### Security
 
 ## [1.7.7]

--- a/include/yall/queue.h
+++ b/include/yall/queue.h
@@ -80,4 +80,11 @@ void enqueue(void *data);
  */
 struct qnode *swap_queue(void);
 
+/**
+ * \brief Reverse the given queue. Tail becomes head and head becomes tail.
+ * \param q Pointer to the queue.
+ * \return Pointer to the reversed queue.
+ */
+struct qnode *queue_reverse(struct qnode *q);
+
 #endif

--- a/src/queue.c
+++ b/src/queue.c
@@ -101,3 +101,25 @@ struct qnode *swap_queue(void)
 
 	return orig_head;
 }
+
+struct qnode *queue_reverse(struct qnode *q)
+{
+	struct qnode *base = NULL;
+	struct qnode *next = NULL;
+
+	while (q) {
+		next = q->next;
+		q->next = NULL;
+
+		if (! base) {
+			base = q;
+		} else {
+			q->next = base;
+			base = q;
+		}
+
+		q = next;
+	}
+
+	return base;
+}

--- a/src/writer/thread.c
+++ b/src/writer/thread.c
@@ -66,6 +66,7 @@ uint8_t start_thread(uint16_t frequency)
 {
 	uint8_t ret = YALL_SUCCESS;
 
+	thread_run = true;
 	thread_frequency = frequency;
 
 	int thread_ret = pthread_create(&thread, NULL, writer_thread, NULL);
@@ -85,29 +86,39 @@ void stop_thread(void)
 /**
  * \brief This function is used to write all the message from the given queue,
  *	through all writer function (write_log_console(), write_log_file(),
- *	...).
+ *	...). The given message queue must be reversed as, for concurrency
+ *	purposes, we can't enqueue message in the proper order. Thus, is the
+ *	queue is not reversed, the messages will be printed in reversed order.
  *	Once the given queue has been wrote, it is freed.
  * \param msg_queue List of messages queue to write.
  */
 static void write_queue_messages(struct qnode *msg_queue)
 {
+	struct qnode *node_next = NULL;
+	struct message *m = NULL;
+
 	if (! msg_queue)
 		return;
 
-	write_queue_messages(msg_queue->next);
+	msg_queue = queue_reverse(msg_queue);
 
-	struct message *m = msg_queue->data;
+	while (msg_queue) {
+		node_next = msg_queue->next;
+		m = msg_queue->data;
 
-	if (yall_console_output & m->output_type)
-		write_log_console(m->log_level, m->data);
+		if (yall_console_output & m->output_type)
+			write_log_console(m->log_level, m->data);
 
-	if (yall_file_output & m->output_type)
-		write_log_file(m->file.filename, m->data);
+		if (yall_file_output & m->output_type)
+			write_log_file(m->file.filename, m->data);
 
-	if (yall_syslog_output & m->output_type)
-		write_log_syslog(m->log_level, m->data);
+		if (yall_syslog_output & m->output_type)
+			write_log_syslog(m->log_level, m->data);
 
-	qnode_delete(msg_queue, message_delete_wrapper);
+		qnode_delete(msg_queue, message_delete_wrapper);
+
+		msg_queue = node_next;
+	}
 }
 
 /**

--- a/tests/c/CMakeLists.txt
+++ b/tests/c/CMakeLists.txt
@@ -7,7 +7,7 @@ add_executable(yall_c main.c)
 if (UNIX)
 	# Compile options
 	set(_PVT_OPT -Wall -Wextra -std=gnu11)
-	set(_PVT_OPT_DEBUG -O0)
+	set(_PVT_OPT_DEBUG -O0 -g)
 	set(_PVT_OPT_RELEASE -O3)
 elseif (WIN32)
 	# Compile options

--- a/tests/c/main.c
+++ b/tests/c/main.c
@@ -24,6 +24,7 @@
 
 #include <stdio.h>
 #include <pthread.h>
+#include <time.h>
 
 #include <yall/yall.h>
 
@@ -103,6 +104,34 @@ void *thread4(void *args)
 	return NULL;
 }
 
+void benchmark_output(uint32_t loops, uint32_t nb_messages)
+{
+	double t_dt_s = 0;
+
+	for (uint32_t i = 0; i < loops; ++i) {
+		clock_t begin = clock();
+
+		yall_init();
+		yall_set_subsystem("yall_c_test", NULL, yall_debug, yall_console_output, NULL);
+
+		for (uint32_t j = 0; j < nb_messages; ++j) {
+			YALL_DEBUG("yall_c_test", "message %d", j);
+		}
+
+		yall_close_all();
+
+		clock_t elapsed = clock() - begin;
+		t_dt_s += (double)elapsed / CLOCKS_PER_SEC;
+	}
+
+	uint32_t t_msg = nb_messages * loops;
+
+	printf("Benchmark results:\n");
+	printf("\tTotal time: %.3lfs\n", t_dt_s);
+	printf("\tTime for %d messages (avg.): %.3lfs\n", nb_messages, t_dt_s / loops);
+	printf("\tMessages per second (avg.): %.0lf\n", (double)t_msg / (double)t_dt_s);
+}
+
 int main(int argc, char *argv[])
 {
 	const char *config_file = NULL;
@@ -129,7 +158,6 @@ int main(int argc, char *argv[])
 	yall_set_subsystem("debug", "yall_c_tests", yall_debug, yall_console_output, NULL);
 	yall_set_subsystem("syslog_yall", NULL, yall_debug, yall_syslog_output, NULL);
 	yall_enable_debug("debug");
-
 
 	yall_load_configuration(config_file);
 	yall_show_subsystems_tree();

--- a/tests/unit/queue/test_enqueue.c
+++ b/tests/unit/queue/test_enqueue.c
@@ -27,7 +27,7 @@
 /*
  * O.K.
  */
-Test(error, test_enqueue0)
+Test(queue, test_enqueue0)
 {
 	enqueue(NULL);
 

--- a/tests/unit/queue/test_qnode_delete.c
+++ b/tests/unit/queue/test_qnode_delete.c
@@ -27,7 +27,7 @@
 /*
  * O.K.
  */
-Test(error, test_qnode_delete0)
+Test(queue, test_qnode_delete0)
 {
 	struct qnode *n = qnode_new(NULL);
 
@@ -40,7 +40,7 @@ Test(error, test_qnode_delete0)
  * O.K.
  * Using custom deleter
  */
-Test(error, test_qnode_delete1)
+Test(queue, test_qnode_delete1)
 {
 	struct qnode *n = qnode_new(NULL);
 

--- a/tests/unit/queue/test_queue_reverse.c
+++ b/tests/unit/queue/test_queue_reverse.c
@@ -26,29 +26,26 @@
 
 /*
  * O.K.
+ * NULL queue
  */
-Test(queue, test_qnode_new0)
+Test(queue, test_queue_reverse0)
 {
-	struct qnode *n = qnode_new(strdup("test"));
-
-	cr_assert(n != NULL);
-	cr_assert_eq(NULL, n->next);
-	cr_assert_str_eq("test", n->data);
-
-	qnode_delete(n, NULL);
+	cr_assert_eq(queue_reverse(NULL), NULL);
 }
 
 /*
  * O.K.
- * NULL data
+ * Non-NULL queue
  */
-Test(queue, test_qnode_new1)
+Test(queue, test_queue_reverse1)
 {
-	struct qnode *n = qnode_new(NULL);
+	struct qnode q0 = { NULL, NULL };
+	struct qnode q1 = { &q0, NULL };
+	struct qnode q2 = { &q1, NULL };
 
-	cr_assert(n != NULL);
-	cr_assert_eq(NULL, n->next);
-	cr_assert_eq(NULL, n->data);
+	struct qnode *r = queue_reverse(&q2);
 
-	qnode_delete(n, NULL);
+	cr_assert_eq(r, &q0);
+	cr_assert_eq(r->next, &q1);
+	cr_assert_eq(r->next->next, &q2);
 }

--- a/tests/unit/queue/test_swap_queue.c
+++ b/tests/unit/queue/test_swap_queue.c
@@ -27,7 +27,7 @@
 /*
  * O.K.
  */
-Test(error, test_swap_queue0)
+Test(queue, test_swap_queue0)
 {
 	enqueue(NULL);
 	struct qnode *n = head;
@@ -39,7 +39,7 @@ Test(error, test_swap_queue0)
  * O.K.
  * NULL head
  */
-Test(error, test_swap_queue1)
+Test(queue, test_swap_queue1)
 {	
 	cr_assert_eq(NULL, swap_queue());
 }


### PR DESCRIPTION
Fix stack overflow when too many messages are printed.

The solution does use a function to reverse the order of a single-linked list. Maybe, replacing this fix by a linked-list algorithm which is able to handle multiple-producer and a single consumer in a lock-free way would be better.

Fix #149 