### PR TITLE
Add debug flag on unit test debug build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Deprecated
 ### Removed
 ### Fixed
+* Add `-g` flag to unit test debug build
 * Thread loop timer (integer overflow)
 * Stack overflow when too many messages are printed
 ### Security

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -13,7 +13,7 @@ add_library(yall_unit_src_obj OBJECT ${YALL_SRCS})
 if (UNIX)
 	# Compile options
 	set(_PVT_OPT -fprofile-arcs -ftest-coverage  -Wall -Wextra -std=gnu11)
-	set(_PVT_OPT_DEBUG -O0)
+	set(_PVT_OPT_DEBUG -O0 -g)
 	set(_PVT_OPT_RELEASE -O3)
 elseif (WIN32)
 	# Compile options
@@ -65,7 +65,7 @@ add_executable(yall_unit $<TARGET_OBJECTS:yall_unit_src_obj> ${YALL_UNIT_SRCS})
 if (UNIX)
 	# Compile options
 	set(_PVT_OPT -Wall -Wextra -std=gnu11)
-	set(_PVT_OPT_DEBUG -O0)
+	set(_PVT_OPT_DEBUG -O0 -g)
 	set(_PVT_OPT_RELEASE -O3)
 elseif (WIN32)
 	# Compile options


### PR DESCRIPTION
Unit tests would fail on debug. Fixed now that `-g` flag is set for unit test sources (both yall sources and test sources) on debug build.